### PR TITLE
doc(annotations): removed faulty ---@module annotations

### DIFF
--- a/doc/mega_cmdparse_api.txt
+++ b/doc/mega_cmdparse_api.txt
@@ -17,7 +17,7 @@ Raises:
     a parser to have a name but here, specifically, it must have a name.
 
 Parameters ~
-    {parser} mega.cmdparse.ParserCreator
+    {parser} |mega.cmdparse.ParserCreator|
         The top-level command to define.
 
 ------------------------------------------------------------------------------
@@ -28,11 +28,11 @@ Parameters ~
 Make a function that can auto-complete based on the parser of `parser_creator`.
 
 Parameters ~
-    {parser_creator} mega.cmdparse.ParserCreator
+    {parser_creator} |mega.cmdparse.ParserCreator|
        A function that creates the decision tree that parses text.
 
 Return ~
-    `(fun(_: any, all_text: string, _: any): string[]?)`
+    fun(_: `(any)`, all_text: `(string)`, _: `(any)`): `(string)`[]?
        A deferred function that creates the COMMAND mode parser, runs it, and
        gets all auto-complete values back if any were found.
 
@@ -44,11 +44,11 @@ Return ~
 Create a deferred function that can parse and execute a user's arguments.
 
 Parameters ~
-    {parser_creator} mega.cmdparse.ParserCreator
+    {parser_creator} |mega.cmdparse.ParserCreator|
        A function that creates the decision tree that parses text.
 
 Return ~
-    `(fun(opts: table): nil)`
+    fun(opts: `(table)`): `(nil)`
        A function that will parse the user's arguments.
 
 ------------------------------------------------------------------------------
@@ -62,11 +62,11 @@ If the parser is a child of a subparser then this instance must be given
 a name via `{name="foo"}` or this function will error.
 
 Parameters ~
-    {options} mega.cmdparse.ParameterParserInputOptions | mega.cmdparse.ParameterParserOptions
+    {options} |mega.cmdparse.ParameterParserInputOptions| | |mega.cmdparse.ParameterParserOptions|
        The options that we might pass to `cmdparse.ParameterParser.new`.
 
 Return ~
-    mega.cmdparse.ParameterParser
+    |mega.cmdparse.ParameterParser|
        The created instance.
 
 

--- a/doc/mega_cmdparse_types.txt
+++ b/doc/mega_cmdparse_types.txt
@@ -10,9 +10,9 @@ operation of this Lua plugin.
    The user's customizations for this plugin.
 
 Fields ~
-    {cmdparse} mega.cmdparse.ConfigurationCmdparse?
+    {cmdparse} |mega.cmdparse.ConfigurationCmdparse|?
        All settings that control the command mode tools (parsing, auto-complete, etc).
-    {logging} mega.cmdparse.LoggingConfiguration?
+    {logging} |mega.cmdparse.LoggingConfiguration|?
        Control how and which logs print to file / Neovim.
 
 ------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ Fields ~
    All settings that control the command mode tools (parsing, auto-complete, etc).
 
 Fields ~
-    {auto_complete} mega.cmdparse.ConfigurationCmdparseAutoComplete
+    {auto_complete} |mega.cmdparse.ConfigurationCmdparseAutoComplete|
        The settings that control what happens during auto-completion.
 
 ------------------------------------------------------------------------------
@@ -28,7 +28,7 @@ Fields ~
    The settings that control what happens during auto-completion.
 
 Fields ~
-    {display} {help_flag: `(boolean})`
+    {display} {help_flag: `(boolean)`}
        help_flag = Show / Hide the --help flag during auto-completion.
 
 ------------------------------------------------------------------------------
@@ -48,12 +48,12 @@ Fields ~
        | number Low-level or spammy messages.
        | number An error that was recovered but could be an issue.)?
        Any messages above this level will be logged.
-    {use_console} `(boolean?)`
+    {use_console} `(boolean)`?
        Should print the output to neovim while running. Warning: This is very
        spammy. You probably don't want to enable this unless you have to.
-    {use_file} `(boolean?)`
+    {use_file} `(boolean)`?
        Should write to a file.
-    {output_path} `(string?)`
+    {output_path} `(string)`?
        The default path on-disk where log files will be written to.
        Defaults to "/home/selecaoone/.local/share/nvim/plugin_name.log".
 

--- a/lua/mega/cmdparse/_cli/argparse.lua
+++ b/lua/mega/cmdparse/_cli/argparse.lua
@@ -1,7 +1,4 @@
 --- Parse text into positional / named arguments.
----
----@module 'mega.cmdparse._cli.argparse'
----
 
 local logging = require("mega.logging")
 

--- a/lua/mega/cmdparse/_cli/argparse_helper.lua
+++ b/lua/mega/cmdparse/_cli/argparse_helper.lua
@@ -1,7 +1,4 @@
 --- Make dealing with COMMAND mode parsed arguments a bit easier.
----
----@module 'mega.cmdparse._cli.argparse_helper'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local tabler = require("mega.cmdparse._core.tabler")

--- a/lua/mega/cmdparse/_cli/cli_subcommand.lua
+++ b/lua/mega/cmdparse/_cli/cli_subcommand.lua
@@ -1,7 +1,4 @@
 --- Connect Neovim's COMMAND mode to our Lua functions.
----
----@module 'mega.cmdparse._cli.cli_subcommand'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/_cli/cmdparse/constant.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/constant.lua
@@ -1,7 +1,4 @@
 --- Meaningful global variables to reuse across modules.
----
----@module 'mega.cmdparse._cli.cmdparse.constant'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/_cli/cmdparse/evaluator.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/evaluator.lua
@@ -1,7 +1,4 @@
 --- Parse and evaluate parameters, using CLI arguments.
----
----@module 'mega.cmdparse._cli.cmdparse.evaluator'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local constant = require("mega.cmdparse._cli.cmdparse.constant")

--- a/lua/mega/cmdparse/_cli/cmdparse/help_message.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/help_message.lua
@@ -1,7 +1,4 @@
 --- Functions that make writing / reading / changing help messages.
----
----@module 'mega.cmdparse._cli.cmdparse.help_message'
----
 
 local constant = require("mega.cmdparse._cli.cmdparse.constant")
 local iterator_helper = require("mega.cmdparse._cli.cmdparse.iterator_helper")

--- a/lua/mega/cmdparse/_cli/cmdparse/init.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/init.lua
@@ -1,7 +1,4 @@
 --- Parse text into positional / named arguments.
----
----@module 'mega.cmdparse._cli.cmdparse'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local argparse_helper = require("mega.cmdparse._cli.argparse_helper")

--- a/lua/mega/cmdparse/_cli/cmdparse/iterator_helper.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/iterator_helper.lua
@@ -1,7 +1,4 @@
 --- Generic functions used in other files.
----
----@module 'mega.mega.cmdparse._cli.cmdparse.iterator_helper'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/_cli/cmdparse/matcher.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/matcher.lua
@@ -1,7 +1,4 @@
 --- Match exact / partial text of cmdparse parameters and argparse arguments.
----
----@module 'mega.cmdparse._cli.cmdparse.matcher'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local constant = require("mega.cmdparse._cli.cmdparse.constant")

--- a/lua/mega/cmdparse/_cli/cmdparse/sorter.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/sorter.lua
@@ -1,7 +1,4 @@
 --- Make sorting arguments easier.
----
----@module 'mega.cmdparse._cli.cmdparse.sorter'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local help_message = require("mega.cmdparse._cli.cmdparse.help_message")

--- a/lua/mega/cmdparse/_cli/cmdparse/text_parse.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/text_parse.lua
@@ -1,7 +1,4 @@
 --- Make dealing with raw text from cmdparse types easier to handle.
----
----@module 'mega.cmdparse._cli.cmdparse.text_parse'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 local texter = require("mega.cmdparse._core.texter")

--- a/lua/mega/cmdparse/_cli/cmdparse/types_input.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/types_input.lua
@@ -1,7 +1,4 @@
 --- Functions that fill-in missing values, validate values, etc for cmdparse types.
----
----@module 'mega.cmdparse._cli.cmdparse.types_input'
----
 
 local constant = require("mega.cmdparse._cli.cmdparse.constant")
 local text_parse = require("mega.cmdparse._cli.cmdparse.text_parse")

--- a/lua/mega/cmdparse/_core/configuration.lua
+++ b/lua/mega/cmdparse/_core/configuration.lua
@@ -1,7 +1,4 @@
 --- All functions and data to help customize `cmdparse` for this user.
----
----@module 'mega.cmdparse._core.configuration'
----
 
 local logging = require("mega.logging")
 

--- a/lua/mega/cmdparse/_core/tabler.lua
+++ b/lua/mega/cmdparse/_core/tabler.lua
@@ -1,7 +1,4 @@
 --- Make dealing with Lua tables a bit easier.
----
----@module 'mega.cmdparse._core.tabler'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/_core/texter.lua
+++ b/lua/mega/cmdparse/_core/texter.lua
@@ -1,7 +1,4 @@
 --- Make manipulating Lua text easier.
----
----@module 'mega.cmdparse._core.texter'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/health.lua
+++ b/lua/mega/cmdparse/health.lua
@@ -3,8 +3,6 @@
 --- At minimum, we validate that the user's configuration is correct. But other
 --- checks can happen here if needed.
 ---
----@module 'mega.cmdparse.health'
----
 
 local configuration_ = require("mega.cmdparse._core.configuration")
 local tabler = require("mega.cmdparse._core.tabler")

--- a/lua/mega/cmdparse/init.lua
+++ b/lua/mega/cmdparse/init.lua
@@ -3,8 +3,6 @@
 --- If a function's signature here changes in some incompatible way, this
 --- package must get a new **major** version.
 ---
----@module 'mega.cmdparse'
----
 
 local M = {}
 

--- a/lua/mega/cmdparse/types.lua
+++ b/lua/mega/cmdparse/types.lua
@@ -3,8 +3,6 @@
 --- These types are either required by the Lua API or required for the normal
 --- operation of this Lua plugin.
 ---
----@module 'mega.cmdparse.types'
----
 
 ---@alias vim.log.levels.DEBUG number Messages to show to plugin maintainers.
 ---@alias vim.log.levels.ERROR number Unrecovered issues to show to the plugin users.

--- a/scripts/make_api_documentation/minimal_init.lua
+++ b/scripts/make_api_documentation/minimal_init.lua
@@ -1,3 +1,5 @@
+--- Download dependencies needed to run `make_api_documentation/main.lua`.
+
 for url, directory in pairs({
     ["https://github.com/echasnovski/mini.doc"] = os.getenv("MINI_DOC_DIRECTORY") or "/tmp/mini.doc",
     ["https://github.com/ColinKennedy/mega.vimdoc"] = os.getenv("AGGRO_VIMDOC_DIRECTORY") or "/tmp/mega.vimdoc",

--- a/spec/cmdparse/argparse_spec.lua
+++ b/spec/cmdparse/argparse_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure the argument parser works as expected.
----
----@module 'mega.cmdparse.argparse_spec'
----
 
 local argparse = require("mega.cmdparse._cli.argparse")
 

--- a/spec/cmdparse/autocomplete_spec.lua
+++ b/spec/cmdparse/autocomplete_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure auto-complete works as expected.
----
----@module 'mega.cmdparse.autocomplete_spec'
----
 
 local cmdparse = require("mega.cmdparse._cli.cmdparse")
 local mock_vim = require("test_utilities.mock_vim")

--- a/spec/cmdparse/cmdparse_error_spec.lua
+++ b/spec/cmdparse/cmdparse_error_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure that `cmdparse` errors when it should.
----
----@module 'mega.cmdparse.cmdparse_error_spec'
----
 
 local cmdparse = require("mega.cmdparse._cli.cmdparse")
 local mock_vim = require("test_utilities.mock_vim")

--- a/spec/cmdparse/cmdparse_spec.lua
+++ b/spec/cmdparse/cmdparse_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure that `cmdparse` parses and auto-completes as expected.
----
----@module 'mega.cmdparse.cmdparse_spec'
----
 
 local cmdparse = require("mega.cmdparse._cli.cmdparse")
 local configuration = require("mega.cmdparse._core.configuration")

--- a/spec/cmdparse/configuration_spec.lua
+++ b/spec/cmdparse/configuration_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure configuration health checks succeed or fail where they should.
----
----@module 'mega.cmdparse.configuration_spec'
----
 
 local configuration_ = require("mega.cmdparse._core.configuration")
 local health = require("mega.cmdparse.health")

--- a/spec/cmdparse/manual_cmdparse_spec.lua
+++ b/spec/cmdparse/manual_cmdparse_spec.lua
@@ -1,7 +1,4 @@
 --- Make sure that the old, manual way of setting up cmdparse also works.
----
----@module 'mega.cmdparse.manual_cmdparse_spec'
----
 
 local cli_subcommand = require("mega.cmdparse._cli.cli_subcommand")
 

--- a/spec/minimal_init.lua
+++ b/spec/minimal_init.lua
@@ -1,7 +1,5 @@
 --- Run the is file before you run unittests to download any extra dependencies.
 
---- Run the is file before you run unittests to download any extra dependencies.
-
 local _PLUGINS = {
     ["https://github.com/ColinKennedy/mega.logging"] = os.getenv("MEGA_LOGGING_DIR") or "/tmp/mega.logging",
 }

--- a/spec/test_utilities/mock_vim.lua
+++ b/spec/test_utilities/mock_vim.lua
@@ -1,7 +1,4 @@
 --- Temporarily track when certain built-in Vim commands are called.
----
----@module 'test_utilities.mock_vim'
----
 
 local M = {}
 


### PR DESCRIPTION
`---@module` was incorrectly used in this repo. This is now fixed. Also, mega.vimdoc got some updates that were propagated here, which is why the .txt files changed