### PR TITLE
feat(command): added visual mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ cmdparse.create_user_command(parser)
 Run: `:Test`
 </details>
 
+### Vim Visual Mode
+<details>
+<summary>Print the selected lines</summary>
+
+```lua
+local cmdparse = require("mega.cmdparse")
+
+local parser = cmdparse.ParameterParser.new({ name = "Test", help = "Test visual selection." })
+parser:set_execute(
+    function(data)
+        print(string.format('Start: "%s"', data.options.line1))
+        print(string.format('End: "%s"', data.options.line2))
+    end
+)
+cmdparse.create_user_command(parser)
+```
+
+- Run: `'<,'>Test`
+</details>
+
 ### Automated Value Type Conversions
 <details>
 <summary>Automated value type conversions</summary>

--- a/doc/news.txt
+++ b/doc/news.txt
@@ -6,8 +6,7 @@ Notable changes since mega.cmdparse 1.0
 ===============================================================================
 NEW FEATURES                                     *mega.cmdparse-new-features*
 
-- Added llscheck.yml - A GitHub workflow that detects type annotation issues!
-- Added urlchecker.yml - A GitHub workflow that finds broken URLs!
+- Added support for visual mode!
 
 
 ===============================================================================

--- a/spec/cmdparse/command_spec.lua
+++ b/spec/cmdparse/command_spec.lua
@@ -1,0 +1,57 @@
+--- Make sure "Command API related" functionality works.
+
+local cmdparse = require("mega.cmdparse")
+
+--- Select line `start` to `end_` (inclusive), for `buffer`.
+---
+---@param start integer The first line to select. A 1-or-more value.
+---@param end_ integer The last line to select, inclusive. A 1-or-more value.
+---@param buffer integer? The buffer to affect (if none given, the current buffer is used).
+---
+local function _select_range(start, end_, buffer)
+    buffer = buffer or vim.api.nvim_current_buf()
+    vim.api.nvim_buf_set_mark(buffer, "<", start, 0, {})
+    vim.api.nvim_buf_set_mark(buffer, ">", end_, 0, {})
+    vim.cmd("normal! `<V`>")
+end
+
+describe("command", function()
+    describe("vim argument", function()
+        it("passes vim command information", function()
+            local parser = cmdparse.ParameterParser.new({ name = "Test", help = "Test" })
+            ---@type vim.api.keyset.create_user_command.command_args?
+            local options = nil
+            parser:set_execute(function(data)
+                options = data.options
+            end)
+
+            cmdparse.create_user_command(parser, nil, { range = true })
+
+            local buffer = vim.api.nvim_create_buf(false, true)
+
+            local lines = {
+                "This is line 1",
+                "This is line 2",
+                "This is line 3",
+                "This is line 4",
+                "This is line 5",
+                "This is line 6",
+                "This is line 7",
+                "This is line 8",
+            }
+
+            vim.api.nvim_buf_set_lines(buffer, 0, -1, false, lines)
+            vim.api.nvim_set_current_buf(buffer)
+            _select_range(3, 7, buffer)
+
+            vim.cmd([['<,'>Test]])
+
+            -- NOTE: By the time `Test` runs, we should have the data we need
+            ---@cast options vim.api.keyset.create_user_command.command_args
+
+            assert.equal(3, options.line1)
+            assert.equal(7, options.line2)
+            assert.equal(-1, options.smods.verbose)
+        end)
+    end)
+end)

--- a/spec/cmdparse/manual_cmdparse_spec.lua
+++ b/spec/cmdparse/manual_cmdparse_spec.lua
@@ -28,6 +28,7 @@ describe("run", function()
             },
         })
 
+        ---@diagnostic disable-next-line: missing-fields
         triager({ fargs = { "some_subcommand" }, args = "some_subcommand more stuff" })
 
         assert.same({


### PR DESCRIPTION
Closes: https://github.com/ColinKennedy/mega.cmdparse/issues/22

@teto Please let me know if this branch isn't working for you. It should work as-is

```lua
{
    "ColinKennedy/mega.cmdparse",
    branch = "issues/22-add_visual_selection",
    dependencies = { "ColinKennedy/mega.logging" },
    version = "v1.*",
}
```

- Add `{ range = true }` to `create_user_command`, e.g. `cmdparse.create_user_command(parser, nil, { range = true })`
- Access line-selection info using...

```lua
            parser:set_execute(function(data)
                data.options.line1
                data.options.line2
            end)
```
