### PR TITLE
fix(parameter): default=true now works with positional parameters

### DIFF
--- a/lua/mega/cmdparse/_cli/cmdparse/types_input.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/types_input.lua
@@ -175,10 +175,10 @@ function M.expand_parameter_options(options, is_position)
     end
 
     if options.required == nil then
-        if is_position then
+        options.required = false
+
+        if is_position and not options.default then
             options.required = options.count ~= constant.Counter.zero_or_more
-        else
-            options.required = false
         end
     end
 

--- a/spec/cmdparse/cmdparse_error_spec.lua
+++ b/spec/cmdparse/cmdparse_error_spec.lua
@@ -677,12 +677,30 @@ describe("defaults", function()
         assert.is_true(vim.endswith(message, "cannot have a default and required=true at the same time. Please fix!"))
 
         success = pcall(function()
-            parser:add_parameter({ name = "bad", default = 8, required = false, help = "A bad parameter." })
+            parser:add_parameter({
+                name = "good_1",
+                default = 8,
+                required = false,
+                help = "A parameter that defines a default and a (redundant) required=false",
+            })
         end)
         assert.is_true(success)
 
         success = pcall(function()
-            parser:add_parameter({ name = "bad", required = true, help = "A bad parameter." })
+            parser:add_parameter({
+                name = "good_2",
+                default = 8,
+                help = "A parameter that is implicitly required=false.",
+            })
+        end)
+        assert.is_true(success)
+
+        success = pcall(function()
+            parser:add_parameter({
+                name = "good_3",
+                required = true,
+                help = "A position parameter with a (redundant) required=true",
+            })
         end)
         assert.is_true(success)
     end)


### PR DESCRIPTION
Relates: https://github.com/ColinKennedy/mega.cmdparse/issues/16

Whoops, position parameters were erroring when a non-nil default was given. This is now fixed