### PR TITLE
fix(help): remainder parameters now print correctly

### DIFF
--- a/lua/mega/cmdparse/_cli/cmdparse/init.lua
+++ b/lua/mega/cmdparse/_cli/cmdparse/init.lua
@@ -720,8 +720,15 @@ function _P.get_usage_summary(parser)
         end
     end
 
+    ---@type mega.cmdparse.Parameter[]
+    local remainder_parameters = {}
+
     for _, position in ipairs(parser:get_position_parameters()) do
-        table.insert(output, help_message.get_position_usage_help_text(position))
+        if position:get_nargs() == argparse.REMAINDER then
+            table.insert(remainder_parameters, position)
+        else
+            table.insert(output, help_message.get_position_usage_help_text(position))
+        end
     end
 
     for _, flag in ipairs(iterator_helper.sort_parameters(parser:get_flag_parameters({ hide_implicits = true }))) do
@@ -736,6 +743,11 @@ function _P.get_usage_summary(parser)
 
     for _, flag in ipairs(iterator_helper.sort_parameters(parser:get_implicit_flag_parameters())) do
         table.insert(output, string.format("[%s]", flag:get_raw_name()))
+    end
+
+    for _, position in ipairs(remainder_parameters) do
+        local label = string.format("[%s %s]", argparse.REMAINDER, help_message.get_position_usage_help_text(position))
+        table.insert(output, label)
     end
 
     return help_message.HELP_MESSAGE_PREFIX .. vim.fn.join(output, " ")

--- a/spec/cmdparse/cmdparse_spec.lua
+++ b/spec/cmdparse/cmdparse_spec.lua
@@ -431,6 +431,25 @@ Options:
             )
         end)
 
+        it("shows remainder at the end #ttt", function()
+            local parser = cmdparse.ParameterParser.new({ name = "top", help = "Test." })
+            parser:add_parameter({ "--items", help = "Thing." })
+            parser:add_parameter({ name = "remainder", nargs = argparse.REMAINDER, help = "Etc." })
+
+            assert.equal(
+                [[Usage: top [--items ITEMS] [--help] [-- REMAINDER]
+
+Positional Arguments:
+    REMAINDER    Etc.
+
+Options:
+    --items ITEMS    Thing.
+    --help -h    Show this help message and exit.
+]],
+                parser:get_full_help("")
+            )
+        end)
+
         it("works with a parser that has more than one choice for its name", function()
             local parser = cmdparse.ParameterParser.new({ help = "Test." })
             local subparsers = parser:add_subparsers({ destination = "commands", help = "Test." })


### PR DESCRIPTION
Closes: https://github.com/ColinKennedy/mega.cmdparse/issues/30

Pleases `-- REMAINDER` at the end of the parse, which is the correct position. And wraps it with `[]`s, to indicate that is optional, similar to a flag.